### PR TITLE
Fix Sass deprecation warnings by migrating @import to @use

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2,6 +2,8 @@
 # Add a comment to make this file sass-y.
 # Change this file for any custom CSS.
 ---
+@use "syntax";
+@use "starsnonscss";
 
 /* We need to add display:inline in order to align the '>>' of the 'read more' link */
 .post-excerpt p {
@@ -31,9 +33,3 @@
 .home-icon {
 	color: #1C9963
 }
-
-// Import partials from `sass_dir` (defaults to `_sass`)
-@import
-	"syntax",
-    "starsnonscss"
-;


### PR DESCRIPTION
In Dart Sass 3.0.0, the `@import` rule is deprecated and will be removed. During the build process, Jekyll reported warnings related to `@import "syntax"` and `@import "starsnonscss"` in `assets/css/main.scss`. This commit migrates these to the new `@use` module system to avoid future build failures and keep the codebase up-to-date. The `@use` statements are placed at the very top of the SCSS after the frontmatter, conforming to Sass requirements.

---
*PR created automatically by Jules for task [15683908072513285250](https://jules.google.com/task/15683908072513285250) started by @dante0747*